### PR TITLE
优化代码

### DIFF
--- a/autockt/envs/ngspice_vanilla_opamp.py
+++ b/autockt/envs/ngspice_vanilla_opamp.py
@@ -134,29 +134,22 @@ class TwoStageAmp(gym.Env):
 
     @debug_log
     def reset(self):
-        # if multi-goal is selected, every time reset occurs, it will select a different design spec as objective
-        if self.generalize == True:
-            if self.valid == True:
+        # 合并多目标选择逻辑
+        if self.generalize or self.multi_goal:
+            if self.generalize and self.valid:
+                # 顺序循环选择索引
                 if self.obj_idx > self.num_os - 1:
                     self.obj_idx = 0
                 idx = self.obj_idx
                 self.obj_idx += 1
             else:
+                # 随机选择索引
                 idx = random.randint(0, self.num_os - 1)
-            self.specs_ideal = []
-            for spec in list(self.specs.values()):
-                self.specs_ideal.append(spec[idx])
-            self.specs_ideal = np.array(self.specs_ideal)
+            # 统一生成目标规格数组
+            self.specs_ideal = np.array([spec[idx] for spec in self.specs.values()])
         else:
-            if self.multi_goal == False:
-                self.specs_ideal = self.g_star
-            else:
-                idx = random.randint(0, self.num_os - 1)
-                self.specs_ideal = []
-                for spec in list(self.specs.values()):
-                    self.specs_ideal.append(spec[idx])
-                self.specs_ideal = np.array(self.specs_ideal)
-        # print("num total:"+str(self.num_os))
+            # 单目标情况，使用固定规格
+            self.specs_ideal = self.g_star
 
         # applicable only when you have multiple goals, normalizes everything to some global_g
         self.specs_ideal_norm = self.lookup(self.specs_ideal, self.global_g)

--- a/eval_engines/ngspice/ngspice_wrapper.py
+++ b/eval_engines/ngspice/ngspice_wrapper.py
@@ -53,11 +53,12 @@ class NgSpiceWrapper(object):
 
     @debug_log
     def create_design(self, state, new_fname):
-
-        # 根据给定的参数 state 生成新的设计文件
-        # :param state: 电路设计参数字典
-        # :param new_fname: 生成的新文件名
-        # :return: 生成的电路设计文件所在的文件夹和路径
+        """
+         根据给定的参数 state 生成新的设计文件
+         :param state: 电路设计参数字典
+         :param new_fname: 生成的新文件名
+         :return: 生成的电路设计文件所在的文件夹和路径
+        """
 
         design_folder = os.path.join(self.gen_dir, new_fname) + str(random.randint(0, 10000))
         os.makedirs(design_folder, exist_ok=True)
@@ -78,13 +79,13 @@ class NgSpiceWrapper(object):
                     pass  # do not change the model path
             if '.param' in line:
                 for key, value in state.items():
-                    regex = re.compile("%s=(\S+)" % (key)) #遍历每一个字典，查找有无匹配的key=value的形式的param，若有，则需要用regex函数进行匹配并进行提取
+                    regex = re.compile("%s=(\S+)" % (key))  # 遍历每一个字典，查找有无匹配的key=value的形式的param，若有，则需要用regex函数进行匹配并进行提取
                     found = regex.search(line)
                     if found:
                         new_replacement = "%s=%s" % (key, str(value))
                         lines[line_num] = lines[line_num].replace(found.group(0), new_replacement)
             if 'wrdata' in line:
-                regex = re.compile("wrdata\s*(\w+\.\w+)\s*") #捕获文件名，要求文件名格式为"xxx.yyy"（使用（\w+\.\w+)捕获文件名)
+                regex = re.compile("wrdata\s*(\w+\.\w+)\s*")  # 捕获文件名，要求文件名格式为"xxx.yyy"（使用（\w+\.\w+)捕获文件名)
                 found = regex.search(line)
                 if found:
                     replacement = os.path.join(design_folder, found.group(1))
@@ -98,8 +99,8 @@ class NgSpiceWrapper(object):
     @debug_log
     def simulate(self, fpath):
         info = 0  # this means no error occurred
-        command = "ngspice -b %s >/dev/null 2>&1" % fpath #NGSpice的命令形式，目的是运行NGSpice仿真并且防止NGSpice有过多的输出
-        exit_code = os.system(command) #os.system返回command的输出状态，值为非0和0两种
+        command = "ngspice -b %s >/dev/null 2>&1" % fpath  # NGSpice的命令形式，目的是运行NGSpice仿真并且防止NGSpice有过多的输出
+        exit_code = os.system(command)  # os.system返回command的输出状态，值为非0和0两种
         if debug:
             print(command)
             print(fpath)
@@ -135,9 +136,10 @@ class NgSpiceWrapper(object):
         :return:
             results = [(state: dict(param_kwds, param_value), specs: dict(spec_kwds, spec_value), info: int)]
         """
-        pool = ThreadPool(processes=self.num_process) #创建一个多线程池，进行多个仿真任务，self.num_process为线程数量
+        pool = ThreadPool(processes=self.num_process)  # 创建一个多线程池，进行多个仿真任务，self.num_process为线程数量
         arg_list = [(state, dsn_name, verbose) for (state, dsn_name) in zip(states, design_names)]
-        specs = pool.starmap(self.create_design_and_simulate, arg_list) #starmap自动展开arg_;ist，传递参数给create_design_and_simulate进行设计仿真
+        specs = pool.starmap(self.create_design_and_simulate,
+                             arg_list)  # starmap自动展开arg_;ist，传递参数给create_design_and_simulate进行设计仿真
         pool.close()
         return specs
 
@@ -153,4 +155,3 @@ class NgSpiceWrapper(object):
         """
         result = None
         return result
-


### PR DESCRIPTION
1.合并spec计算冗余代码
2.优化模型reset逻辑，将训练iters从240-50轮降回183轮左右/15mins
训练验证均可跑通，模型收敛加快
![image](https://github.com/user-attachments/assets/9a0a404e-03a8-438b-960e-d75b7b6c392b)
![image](https://github.com/user-attachments/assets/371c3014-4375-4c45-82e6-4cbfab666312)
![image](https://github.com/user-attachments/assets/91eb2ccf-ac9d-44fa-84cf-9c59be5f05ad)
