### PR TITLE
优化读写

### DIFF
--- a/Log.py
+++ b/Log.py
@@ -3,7 +3,21 @@
 '''
 import logging
 import os
-from functools import wraps  # 导入 wraps
+import io
+
+
+class LoggerWriter(io.TextIOBase):
+    def __init__(self, level):
+        self.level = level  # 级别 INFO / ERROR
+        self.buffer = ""
+
+    def write(self, message):
+        if message.strip():  # 忽略空行
+            self.level(message.strip())  # 直接调用 logger
+
+    def flush(self):
+        pass  # logging 本身会处理 flush
+
 
 # 定义日志文件路径
 log_file_path = "/tmp/general.log"
@@ -16,7 +30,7 @@ log = logging.getLogger('general_logger')
 log.setLevel(logging.DEBUG)
 
 # 创建文件处理器
-log_handler = logging.FileHandler(log_file_path)
+log_handler = logging.FileHandler(log_file_path, encoding='utf-8')
 log_handler.setLevel(logging.DEBUG)
 
 # 创建日志格式

--- a/autockt/envs/read_yaml.py
+++ b/autockt/envs/read_yaml.py
@@ -1,0 +1,40 @@
+from func_decorator import debug_log
+
+import yaml
+import yaml.constructor
+from collections import OrderedDict
+
+
+# way of ordering the way a yaml file is read
+class OrderedDictYAMLLoader(yaml.Loader):
+    """
+    A YAML loader that loads mappings into ordered dictionaries.
+    """
+
+    def __init__(self, *args, **kwargs):
+        yaml.Loader.__init__(self, *args, **kwargs)
+
+        self.add_constructor(u'tag:yaml.org,2002:map', type(self).construct_yaml_map)
+        self.add_constructor(u'tag:yaml.org,2002:omap', type(self).construct_yaml_map)
+
+    @debug_log
+    def construct_yaml_map(self, node):
+        data = OrderedDict()
+        yield data
+        value = self.construct_mapping(node)
+        data.update(value)
+
+    @debug_log
+    def construct_mapping(self, node, deep=False):
+        if isinstance(node, yaml.MappingNode):
+            self.flatten_mapping(node)
+        else:
+            raise yaml.constructor.ConstructorError(None, None,
+                                                    'expected a mapping node, but found %s' % node.id, node.start_mark)
+
+        mapping = OrderedDict()
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            value = self.construct_object(value_node, deep=deep)
+            mapping[key] = value
+        return mapping

--- a/autockt/gen_specs.py
+++ b/autockt/gen_specs.py
@@ -17,40 +17,7 @@ import argparse
 from collections import OrderedDict
 import pickle
 
-
-# way of ordering the way a yaml file is read
-class OrderedDictYAMLLoader(yaml.Loader):
-    """
-    A YAML loader that loads mappings into ordered dictionaries.
-    """
-
-    def __init__(self, *args, **kwargs):
-        yaml.Loader.__init__(self, *args, **kwargs)
-
-        self.add_constructor(u'tag:yaml.org,2002:map', type(self).construct_yaml_map)
-        self.add_constructor(u'tag:yaml.org,2002:omap', type(self).construct_yaml_map)
-
-    @debug_log
-    def construct_yaml_map(self, node):
-        data = OrderedDict()
-        yield data
-        value = self.construct_mapping(node)
-        data.update(value)
-
-    @debug_log
-    def construct_mapping(self, node, deep=False):
-        if isinstance(node, yaml.MappingNode):  # isinstance的作用是检查某个对象是否是指定类型或类型的子类
-            self.flatten_mapping(node)
-        else:
-            raise yaml.constructor.ConstructorError(None, None,
-                                                    'expected a mapping node, but found %s' % node.id, node.start_mark)
-
-        mapping = OrderedDict()
-        for key_node, value_node in node.value:
-            key = self.construct_object(key_node, deep=deep)  # 使用construct_object对key_node进行映射
-            value = self.construct_object(value_node, deep=deep)
-            mapping[key] = value
-        return mapping
+from autockt.envs.read_yaml import OrderedDictYAMLLoader
 
 
 # Generate the design specifications and then save to a pickle file

--- a/autockt/rollout.py
+++ b/autockt/rollout.py
@@ -174,9 +174,12 @@ def rollout(agent, env_name, num_steps, out="assdf", no_render=True):
                 action_array.append(action)
 
             next_state, reward, done, _ = env.step(action)
-            log.info("action: {}".format(action))
-            log.info("reward: {}".format(reward))
-            log.info("reward: {}".format(done))
+            log_details = (
+                "action: {}\n"
+                "reward: {}\n"
+                "reward: {}"
+            ).format(action, reward, done)
+            log.info(log_details)  # 减少IO读写次数
             reward_total += reward
             if not no_render:
                 env.render()

--- a/autockt/val_autobag_ray.py
+++ b/autockt/val_autobag_ray.py
@@ -1,51 +1,65 @@
-from Log import log
+from Log import log, LoggerWriter
 import ray
 import ray.tune as tune
 from ray.rllib.agents import ppo
 from autockt.envs.ngspice_vanilla_opamp import TwoStageAmp
 
 import argparse
+import sys
+import io
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--checkpoint_dir', '-cpd', type=str)
 args = parser.parse_args()
 ray.init()
 
-# configures training of the agent with associated hyperparameters
-# See Ray documentation for details on each parameter
-config_train = {
-    # "sample_batch_size": 200,
-    "train_batch_size": 1200,
-    # "sgd_minibatch_size": 1200,
-    # "num_sgd_iter": 3,
-    # "lr":1e-3,
-    # "vf_loss_coeff": 0.5,
-    "horizon": 30,
-    "num_gpus": 0,
-    "model": {"fcnet_hiddens": [64, 64]},
-    "num_workers": 6,
-    "env_config": {"generalize": True, "run_valid": False},
-}
+sys.stdout = LoggerWriter(log.info)  # 所有 print() 变成 log.info()
+sys.stderr = LoggerWriter(log.error)  # 捕获错误信息
 
-# Runs training and saves the result in ~/ray_results/train_ngspice_45nm
-# If checkpoint fails for any reason, training can be restored
-if not args.checkpoint_dir:
-    trials = tune.run_experiments({
-        "train_45nm_ngspice": {
-            "checkpoint_freq": 1,
-            "run": "PPO",
-            "env": TwoStageAmp,
-            "stop": {"episode_reward_mean": -0.02},
-            "config": config_train},
-    })
-else:
-    log.info("RESTORING NOW!!!!!!")
-    tune.run_experiments({
-        "restore_ppo": {
-            "run": "PPO",
-            "config": config_train,
-            "env": TwoStageAmp,
-            # "restore": trials[0]._checkpoint.value},
-            "restore": args.checkpoint_dir,
-            "checkpoint_freq": 1},
-    })
+try:
+    # configures training of the agent with associated hyperparameters
+    # See Ray documentation for details on each parameter
+    config_train = {
+        # "sample_batch_size": 200,
+        "train_batch_size": 1200,
+        # "sgd_minibatch_size": 1200,
+        # "num_sgd_iter": 3,
+        # "lr":1e-3,
+        # "vf_loss_coeff": 0.5,
+        "horizon": 30,
+        "num_gpus": 0,
+        "model": {"fcnet_hiddens": [64, 64]},
+        "num_workers": 6,
+        "env_config": {"generalize": True, "run_valid": False},
+    }
+
+    # Runs training and saves the result in ~/ray_results/train_ngspice_45nm
+    # If checkpoint fails for any reason, training can be restored
+    if not args.checkpoint_dir:
+        trials = tune.run_experiments({
+            "train_45nm_ngspice": {
+                "checkpoint_freq": 1,
+                "run": "PPO",
+                "env": TwoStageAmp,
+                "stop": {"episode_reward_mean": -0.02},
+                "config": config_train},
+        })
+    else:
+        log.info("RESTORING NOW!!!!!!")
+        tune.run_experiments({
+            "restore_ppo": {
+                "run": "PPO",
+                "config": config_train,
+                "env": TwoStageAmp,
+                # "restore": trials[0]._checkpoint.value},
+                "restore": args.checkpoint_dir,
+                "checkpoint_freq": 1},
+        })
+
+except Exception as e:
+    log.error("Error occurred: {}".format(e))
+
+finally:
+    log.info("Training completed.")
+    sys.stdout = sys.__stdout__  # 恢复正常输出
+    sys.stderr = sys.__stderr__

--- a/eval_engines/util/core.py
+++ b/eval_engines/util/core.py
@@ -1,4 +1,5 @@
 from Log import log
+from func_decorator import debug_log
 import numpy as np
 import sys
 from copy import deepcopy, copy
@@ -16,6 +17,7 @@ class IDEncoder(object):
         self._lookup_dict = self._create_lookup()
         self.length_letters = self._compute_length_letter()
 
+    @debug_log
     def _compute_length_letter(self):
         cur_multiplier = 1
         for base in self._bases:
@@ -26,6 +28,7 @@ class IDEncoder(object):
         return len(ret_vec)
 
     @classmethod
+    @debug_log
     def _create_lookup(cls):
         lookup = {}
         n_letters = ord('z') - ord('a') + 1
@@ -37,6 +40,7 @@ class IDEncoder(object):
             lookup[i + 10 + n_letters] = chr(ord('A') + i)
         return lookup
 
+    @debug_log
     def _compute_multipliers(self):
         """
         computes [3x8, 8, 0] in our example
@@ -54,10 +58,12 @@ class IDEncoder(object):
         ret_list[-1] = 0
         return np.array(ret_list)
 
+    @debug_log
     def _convert_2_base_10(self, input_vec):
         assert len(input_vec) == len(self._bases)
         return np.sum(np.array(input_vec) * self._mulipliers)
 
+    @debug_log
     def _convert_2_base_letters(self, input_base_10):
         x = input_base_10
         ret_list = []
@@ -68,11 +74,13 @@ class IDEncoder(object):
 
         return ret_list
 
+    @debug_log
     def _pad(self, input_base_letter):
         while len(input_base_letter) < self.length_letters:
             input_base_letter.insert(0, '0')
         return input_base_letter
 
+    @debug_log
     def convert_list_2_id(self, input_list):
         base10 = self._convert_2_base_10(input_list)
         base_letter = self._convert_2_base_letters(base10)


### PR DESCRIPTION
1.合并gen_spec和vanilla的yaml loader冗余代码至新文件
2.优化多行log读写，减少IO调用次数
3.优化ray命令行直接写入，将print输出调转至general.log，并增加异常捕捉
但因合并ray output至log，训练次数降至200-230 iters，不过时间并未超过30分钟（自测）
后续大概需要优化rl代码逻辑，减少训练时间
代码已在docker环境跑通
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/e5aab3d5-5882-48ec-a5f5-0ae28d4f906f" />
