### PR TITLE
优化存储空间+修改存储路径

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,12 @@ RUN yum install -y \
     libX11-devel \
     && yum clean all
 
+RUN mkdir -p /mnt/raid_p310/isrl03ws10a/workspace310a && chmod 777 /mnt/raid_p310/isrl03ws10a/workspace310a
+
+ARG USERNAME=autockt_user
+ARG USER_HOME=/mnt/raid_p310/isrl03ws10a
+RUN useradd -m -d $USER_HOME -s /bin/bash $USERNAME
+
 # 安装 Miniconda（手动指定 Python 3.5 版本）
 ENV CONDA_DIR=/opt/conda
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-4.7.12-Linux-x86_64.sh -O miniconda.sh \
@@ -69,10 +75,15 @@ RUN wget https://sourceforge.net/projects/ngspice/files/ng-spice-rework/old-rele
     && rm -rf ngspice-27*
 
 # 复制 当前（AutoCkt） 文件夹到容器中
-COPY . /app/AutoCkt
+COPY . $USER_HOME/workspace310a/AutoCkt
+RUN chown -R $USERNAME:$USERNAME $USER_HOME
+
+
+USER $USERNAME
+WORKDIR $USER_HOME/workspace310a/AutoCkt
 
 # 创建 Conda 环境
-RUN conda env create -f /app/AutoCkt/environment.yml
+RUN conda env create -f $USER_HOME/workspace310a/AutoCkt/environment.yml
 
 # --------------- 激活环境并设置默认命令 ---------------
 # centos7 需要先初始化 conda
@@ -81,9 +92,6 @@ RUN conda init bash
 # 激活环境并设置默认命令
 RUN echo "conda activate autockt" >> ~/.bashrc
 SHELL ["/bin/bash", "--login", "-c"]
-
-# 设置容器工作目录
-WORKDIR /app/AutoCkt
 
 # 设置容器默认命令
 CMD ["/bin/bash"]

--- a/Log.py
+++ b/Log.py
@@ -20,7 +20,7 @@ class LoggerWriter(io.TextIOBase):
 
 
 # 定义日志文件路径
-log_file_path = "/tmp/general.log"
+log_file_path = os.path.expanduser("~/workspace310a/general.log")
 
 # 确保日志目录存在
 os.makedirs(os.path.dirname(log_file_path), exist_ok=True)

--- a/autockt/val_autobag_ray.py
+++ b/autockt/val_autobag_ray.py
@@ -15,6 +15,26 @@ parser.add_argument('--checkpoint_dir', '-cpd', type=str)
 args = parser.parse_args()
 ray.init()
 
+# 软连接目标路径
+ray_results_target = os.path.expanduser("~/workspace310a/ray_results")
+ray_results_link = os.path.expanduser("~/ray_results")
+
+try:
+    if not os.path.exists(ray_results_target):
+        os.makedirs(ray_results_target)
+        log.info("Created directory: {}".format(ray_results_target))
+
+    # 确保 ~/ray_results 不是目录或已有文件
+    if os.path.exists(ray_results_link) or os.path.islink(ray_results_link):
+        os.remove(ray_results_link)  # 先删除原有的 ~/ray_results（如果存在）
+
+    # 创建软链接
+    os.symlink(ray_results_target, ray_results_link)
+    log.info("Created symlink: {} -> {}".format(ray_results_link, ray_results_target))
+
+except Exception as e:
+    log.error("Failed to create symlink: {}".format(e))
+
 sys.stdout = LoggerWriter(log.info)  # 所有 print() 变成 log.info()
 sys.stderr = LoggerWriter(log.error)  # 捕获错误信息
 

--- a/eval_engines/ngspice/export.ocn
+++ b/eval_engines/ngspice/export.ocn
@@ -1,6 +1,6 @@
 openResults("2opamp.raw")
 selectResult("ac")
-ocnPrint(?output "ac.csv" v("Vout") ?numberNotation "scientific")
+ocnPrint(?output "ac.csv" v("VOUT") ?numberNotation "scientific")
 selectResult("dcOp")
 ocnPrint(?output "dc.csv" i("V1:p") ?numberNotation "scientific")
 exit()

--- a/eval_engines/ngspice/ngspice_inputs/netlist/2opamp
+++ b/eval_engines/ngspice/ngspice_inputs/netlist/2opamp
@@ -1,7 +1,7 @@
 // Generated for: spectre
-// Generated on: Feb 22 16:27:26 2025
-// Design library name: AI_project
-// Design cell name: 2_stage_opamp_tb
+// Generated on: Mar  7 19:22:27 2025
+// Design library name: temporary_lib
+// Design cell name: 2opamp_open_tb
 // Design view name: schematic
 simulator lang=spectre
 global 0
@@ -13,64 +13,63 @@ include "$SPECTRE_MODEL_PATH/design_wrapper.lib.scs" section=APMOMCap_nom
 include "$SPECTRE_MODEL_PATH/design_wrapper.lib.scs" section=MIMCap_nom
 include "$SPECTRE_MODEL_PATH/design_wrapper.lib.scs" section=Ind_nom
 include "$SPECTRE_MODEL_PATH/design_wrapper.lib.scs" section=DioCap_nom
-parameters cc=3p mn1=38 mn3=9 mn4=20 mn5=60 mp1=10 mp3=4
+parameters cc=3p mn1=33 mn3=33 mn4=33 mn5=14 mp1=33 mp3=33
 
-// Library name: AI_project
-// Cell name: 2_stage_opamp
+// Library name: temporary_lib
+// Cell name: 2opamp
 // View name: schematic
-subckt AI_project_2_stage_opamp_schematic I V\+ V\- VDD VSS Vout
-    MN5 (Vout I VSS VSS) dgnfet l=280n w=3.36u ad=705.6f as=705.6f \
-        pd=7.14u ps=7.14u m=mn5 nf=1 par=mn5 par_nf=(1) pccrit=0 ptwell=0 \
-        plnest=1 plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 \
-        p_vta=0 sca=0 scb=0 scc=0 pre_layout_local=-1
-    MN3 (net3 I VSS VSS) dgnfet l=280n w=560n ad=117.6f as=117.6f pd=1.54u \
-        ps=1.54u m=mn3 nf=1 par=mn3 par_nf=(1) pccrit=0 ptwell=0 plnest=1 \
-        plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 p_vta=0 sca=0 \
-        scb=0 scc=0 pre_layout_local=-1
-    MN4 (I I VSS VSS) dgnfet l=280n w=560n ad=117.6f as=117.6f pd=1.54u \
-        ps=1.54u m=mn4 nf=1 par=mn4 par_nf=(1) pccrit=0 ptwell=0 plnest=1 \
-        plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 p_vta=0 sca=0 \
-        scb=0 scc=0 pre_layout_local=-1
-    MN2 (net5 V\+ net3 VSS) dgnfet l=280n w=1.4u ad=294f as=294f pd=3.22u \
-        ps=3.22u m=mn1 nf=1 par=mn1 par_nf=(1) pccrit=0 ptwell=0 plnest=1 \
-        plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 p_vta=0 sca=0 \
-        scb=0 scc=0 pre_layout_local=-1
-    MN1 (net4 V\- net3 VSS) dgnfet l=280n w=1.4u ad=294f as=294f pd=3.22u \
-        ps=3.22u m=mn1 nf=1 par=mn1 par_nf=(1) pccrit=0 ptwell=0 plnest=1 \
-        plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 p_vta=0 sca=0 \
-        scb=0 scc=0 pre_layout_local=-1
-    MP3 (Vout net5 VDD VDD) dgpfet l=500n w=16u ad=3.36p as=3.36p \
-        pd=32.42u ps=32.42u m=mp3 nf=1 par=mp3 par_nf=(1) pccrit=0 \
+subckt temporary_lib_2opamp_schematic v\+ v\- vdd vout vss
+    MP3 (vout net_24 vdd vdd) dgxpfet l=500n w=40u ad=8.4p as=8.4p \
+        pd=80.42u ps=80.42u m=mp3 nf=1 par=mp3 par_nf=(1) pccrit=0 \
         plnest=1 plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 \
         p_vta=0 sca=0 scb=0 scc=0 pre_layout_local=-1 ptwell=0
-    MP2 (net5 net4 VDD VDD) dgpfet l=280n w=1.4u ad=294f as=294f pd=3.22u \
-        ps=3.22u m=mp1 nf=1 par=mp1 par_nf=(1) pccrit=0 plnest=1 \
+    MP2 (net_24 net4 vdd vdd) dgxpfet l=1u w=10u ad=2.1p as=2.1p pd=20.42u \
+        ps=20.42u m=mp1 nf=1 par=mp1 par_nf=(1) pccrit=0 plnest=1 \
         plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 p_vta=0 sca=0 \
         scb=0 scc=0 pre_layout_local=-1 ptwell=0
-    MP1 (net4 net4 VDD VDD) dgpfet l=280n w=1.4u ad=294f as=294f pd=3.22u \
-        ps=3.22u m=mp1 nf=1 par=mp1 par_nf=(1) pccrit=0 plnest=1 \
+    MP1 (net4 net4 vdd vdd) dgxpfet l=1u w=10u ad=2.1p as=2.1p pd=20.42u \
+        ps=20.42u m=mp1 nf=1 par=mp1 par_nf=(1) pccrit=0 plnest=1 \
         plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 p_vta=0 sca=0 \
         scb=0 scc=0 pre_layout_local=-1 ptwell=0
-    C0 (net5 Vout) capacitor c=cc
-ends AI_project_2_stage_opamp_schematic
+    MN5 (vout net7 vss vss) dgxnfet l=1u w=30u ad=6.3p as=6.3p pd=60.42u \
+        ps=60.42u m=mn5 nf=1 par=mn5 par_nf=(1) pccrit=0 ptwell=0 plnest=1 \
+        plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 sca=0 scb=0 \
+        scc=0 p_vta=0 pre_layout_local=-1
+    MN4 (net7 net7 vss vss) dgxnfet l=1u w=5u ad=1.05p as=1.05p pd=10.42u \
+        ps=10.42u m=mn4 nf=1 par=mn4 par_nf=(1) pccrit=0 ptwell=0 plnest=1 \
+        plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 sca=0 scb=0 \
+        scc=0 p_vta=0 pre_layout_local=-1
+    MN3 (net3 net7 vss vss) dgxnfet l=1u w=5u ad=1.05p as=1.05p pd=10.42u \
+        ps=10.42u m=mn3 nf=1 par=mn3 par_nf=(1) pccrit=0 ptwell=0 plnest=1 \
+        plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 sca=0 scb=0 \
+        scc=0 p_vta=0 pre_layout_local=-1
+    MN2 (net_24 v\+ net3 net3) dgxnfet l=1u w=10u ad=2.1p as=2.1p \
+        pd=20.42u ps=20.42u m=mn1 nf=1 par=mn1 par_nf=(1) pccrit=0 \
+        ptwell=0 plnest=1 plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n \
+        sd=0 sca=0 scb=0 scc=0 p_vta=0 pre_layout_local=-1
+    MN1 (net4 v\- net3 net3) dgxnfet l=1u w=10u ad=2.1p as=2.1p pd=20.42u \
+        ps=20.42u m=mn1 nf=1 par=mn1 par_nf=(1) pccrit=0 ptwell=0 plnest=1 \
+        plorient=1 pld200=1 dtemp=0.0 sa=210n sb=210n sd=0 sca=0 scb=0 \
+        scc=0 p_vta=0 pre_layout_local=-1
+    C0 (net_24 vout) capacitor c=cc
+    ibias (vdd net7) isource dc=30u type=dc
+ends temporary_lib_2opamp_schematic
 // End of subcircuit definition.
 
-// Library name: AI_project
-// Cell name: 2_stage_opamp_tb
+// Library name: temporary_lib
+// Cell name: 2opamp_open_tb
 // View name: schematic
-I0 (I V\+ V\- VDD VSS Vout) AI_project_2_stage_opamp_schematic
-V1 (VDD 0) vsource dc=3.6 type=dc
+I0 (V\+ V\- VDD VOUT VSS) temporary_lib_2opamp_schematic
+V1 (VDD 0) vsource dc=3.3 type=dc
 V0 (VSS 0) vsource dc=0 type=dc
-I2 (VDD I) isource dc=30u type=dc
-C0 (Vout VSS) capacitor c=1p
-IPRB0 (V\- Vout) iprobe
-V2 (V\+ 0) vsource dc=1.8 mag=1 phase=0 type=sine sinedc=1.8 ampl=1 \
-        sinephase=0 freq=10K
+V3 (V\- 0) vsource dc=1.8 mag=1 phase=60 type=sine ampl=-500m freq=1K
+V2 (V\+ 0) vsource dc=1.8 mag=1 phase=0 type=sine ampl=500.0m freq=1K
+C0 (VOUT 0) capacitor c=10p
 simulatorOptions options psfversion="1.1.0" reltol=1e-3 vabstol=1e-6 \
     iabstol=1e-12 temp=27 tnom=27 scalem=1.0 scale=1.0 gmin=1e-12 rforce=1 \
     vthmod=vthcc ivthn=300e-9 ivthp=70e-9 ivthw=0 ivthl=0 maxnotes=5 \
     maxwarns=5 digits=5 cols=80 pivrel=1e-3 sensfile="../psf/sens.output" \
-    checklimitdest=psf vdsatmod=gds 
+    checklimitdest=psf vdsatmod=gds
 ac ac start=1 stop=10G annotate=status
 dcOp dc write="spectre.dc" maxiters=150 maxsteps=10000 annotate=status
 dcOpInfo info what=oppoint where=rawfile
@@ -80,4 +79,5 @@ outputParameter info what=output where=rawfile
 designParamVals info what=parameters where=rawfile
 primitives info what=primitives where=rawfile
 subckts info what=subckts where=rawfile
+save VOUT
 saveOptions options save=allpub

--- a/eval_engines/ngspice/ngspice_wrapper.py
+++ b/eval_engines/ngspice/ngspice_wrapper.py
@@ -18,7 +18,7 @@ debug = False
 
 
 class NgSpiceWrapper(object):
-    BASE_TMP_DIR = os.path.abspath("/tmp/ckt_da")
+    BASE_TMP_DIR = os.path.abspath(os.path.expanduser("~/workspace310a/ckt_da"))
     OCEAN_SCRIPT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "export.ocn")
 
     def __init__(self, num_process, yaml_path, path, root_dir=None):
@@ -120,8 +120,11 @@ class NgSpiceWrapper(object):
         
         command = """
         source ~/junzhe/cshrc.gf55BCDlite_v1090
-        spectre "{}" -o "{}" =log output.log
-        ocean -nograph -restore "{}"
+        spectre "{0}" -o "{1}" =log output.log
+        ocean -nograph -restore "{2}"
+        find "{1}" -name ".*.dep" -exec rm -rf {{}} +
+        find "{1}" -name "*.raw" -exec rm -rf {{}} +
+        rm -rf "{1}/output.log"
         """.format(fpath, output_dir, os.path.join(output_dir, "export.ocn"))
         try:
             subprocess.run(command, shell=True, executable="/bin/csh", check=True)


### PR DESCRIPTION
1.将存储路径ckt_da(修改路径)和ray_results（修改软连接）修改至$HOME/workspace310a下，用来适配服务器挂载路径

2.调整ckt_da下网表存储空间，删除仿真后不必要文件，可以将每个step的网表存储从1.4m下降至24k，节省存储空间 

（目前服务器使用centos6.10发行版，glibc为2.12，不符合代码运行最低要求2.14，目前考虑需要s更新至2.14或者启用docker，都需要sudo权限）
更改前
![116b1e83e51309baf39204f1f31567b](https://github.com/user-attachments/assets/a4ceaed2-3e24-4979-baaf-2ca9ad71a141)

更改后
![image](https://github.com/user-attachments/assets/70234950-c83a-4d0c-ae86-292f83bd4b0d)
